### PR TITLE
fix small bug with comments

### DIFF
--- a/app/src/main/java/com/example/hashcache/models/database/values/NoPlayerWithUserIdException.java
+++ b/app/src/main/java/com/example/hashcache/models/database/values/NoPlayerWithUserIdException.java
@@ -1,0 +1,3 @@
+package com.example.hashcache.models.database.values;
+
+public class NoPlayerWithUserIdException extends Exception{}

--- a/app/src/main/java/com/example/hashcache/views/DisplayCommentsActivity.java
+++ b/app/src/main/java/com/example/hashcache/views/DisplayCommentsActivity.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.function.Function;
 
 public class DisplayCommentsActivity extends AppCompatActivity implements Observer {
     private ListView commentsList;


### PR DESCRIPTION
Had a bug where if a player was deleted and if they had made any comments, then all the comments for the monster they had commented on did not show up. Fixed it. 
Behaviour is now that if a user is deleted, their comments won't show up but the comments from other, active, players will. 